### PR TITLE
Override `InputFileDirPath` instead of `InputFilePath`

### DIFF
--- a/Advent2023/Library/BaseLibraryDay.cs
+++ b/Advent2023/Library/BaseLibraryDay.cs
@@ -4,8 +4,8 @@ public abstract class BaseLibraryDay : BaseDay
 {
     protected override string ClassPrefix => "Day";
 
-    public override string InputFilePath =>
+    protected override string InputFileDirPath =>
         Path.Combine(
             Path.GetDirectoryName(Assembly.GetEntryAssembly()!.Location)!,
-            base.InputFilePath);
+            base.InputFileDirPath);
 }


### PR DESCRIPTION
This is the proper way of achieving the desired outcome while still leaving flexibility for overriding `InputFilePath` for any specific days if needed.