### PR TITLE
Remove unneeded `ClassPrefix` override

### DIFF
--- a/Advent2023/Library/BaseLibraryDay.cs
+++ b/Advent2023/Library/BaseLibraryDay.cs
@@ -2,8 +2,6 @@
 
 public abstract class BaseLibraryDay : BaseDay
 {
-    protected override string ClassPrefix => "Day";
-
     public override string InputFilePath =>
         Path.Combine(
             Path.GetDirectoryName(Assembly.GetEntryAssembly()!.Location)!,


### PR DESCRIPTION
Library `BaseDay`, which you're inheriting does exactly the same, so if I'm not mistaken this override is not needed.
For reference: https://github.com/eduherminio/AoCHelper/blob/main/src/AoCHelper/BaseDay.cs

```csharp
    /// <summary>
    /// <see cref="BaseProblem"/> with custom <see cref="BaseProblem.ClassPrefix"/> ("Day") and <see cref="BaseProblem.InputFileExtension"/> (".txt")
    /// </summary>
    public abstract class BaseDay : BaseProblem
    {
        /// <summary>
        /// <inheritdoc/>
        /// </summary>
        protected override string ClassPrefix { get; } = "Day";
    }
```